### PR TITLE
Added argument for minimum number of expected tests.

### DIFF
--- a/EnsureTests/task.json
+++ b/EnsureTests/task.json
@@ -26,7 +26,7 @@
       "type": "int",
       "label": "Minimum number of expected tests",
       "required": true,
-      "defaultValue": 0
+      "defaultValue": 1
     }
   ],
   "execution": {

--- a/EnsureTests/task.json
+++ b/EnsureTests/task.json
@@ -21,6 +21,13 @@
   "preview": true,
   "instanceNameFormat": "Ensure tests have executed",
   "inputs": [
+    {
+      "name": "minNumOfExpectedTests",
+      "type": "int",
+      "label": "Minimum number of expected tests",
+      "required": true,
+      "defaultValue": 0
+    }
   ],
   "execution": {
     "HttpRequest": {
@@ -31,7 +38,7 @@
         "Body": "",
         "Headers":"{\n\"Content-Type\":\"application/json\"\n, \"Authorization\":\"Bearer $(system.accesstoken)\"\n}",
         "WaitForCompletion": "false",
-        "Expression": "lt(0, jsonpath('$.aggregatedResultsAnalysis.totalTests')[0])"
+        "Expression": "lt($(minNumOfExpectedTests), jsonpath('$.aggregatedResultsAnalysis.totalTests')[0])"
       }
     }
   }

--- a/EnsureTests/task.json
+++ b/EnsureTests/task.json
@@ -38,7 +38,7 @@
         "Body": "",
         "Headers":"{\n\"Content-Type\":\"application/json\"\n, \"Authorization\":\"Bearer $(system.accesstoken)\"\n}",
         "WaitForCompletion": "false",
-        "Expression": "lt($(minNumOfExpectedTests), jsonpath('$.aggregatedResultsAnalysis.totalTests')[0])"
+        "Expression": "lte($(minNumOfExpectedTests), jsonpath('$.aggregatedResultsAnalysis.totalTests')[0])"
       }
     }
   }

--- a/EnsureTests/task.json
+++ b/EnsureTests/task.json
@@ -26,7 +26,10 @@
       "type": "int",
       "label": "Minimum number of expected tests",
       "required": true,
-      "defaultValue": 1
+      "defaultValue": 1,
+      "properties": {
+        "isVariableOrNonNegativeNumber": "true"
+      }
     }
   ],
   "execution": {


### PR DESCRIPTION
Sometimes only some of tests can be disabled (by mistake). It can be useful to be able to set minimum number of expected test results.

I am not sure if the solution I propose is valid, I haven't tested that. @jessehouwing please understand this PR as an idea and consider whether it make sense for you.